### PR TITLE
Feat: new flyway script to add the new global share permission to sec_permission

### DIFF
--- a/src/main/resources/db/migration/postgresql/V2.15.0.20240515220400_atlas_global_share_permission.sql
+++ b/src/main/resources/db/migration/postgresql/V2.15.0.20240515220400_atlas_global_share_permission.sql
@@ -1,5 +1,5 @@
 INSERT INTO ${ohdsiSchema}.sec_permission
 (value, description)
 values
-('cohortdefinition:global:share:put', 'special permission (intended for admins) that allows the user to share any cohort with a "global reader role"')
+('artifact:global:share:put', 'special permission (intended for admins) that allows the user to share any artifact with a "global reader role"')
 ;

--- a/src/main/resources/db/migration/postgresql/V2.15.0.20240515220400_atlas_global_share_permission.sql
+++ b/src/main/resources/db/migration/postgresql/V2.15.0.20240515220400_atlas_global_share_permission.sql
@@ -1,0 +1,5 @@
+INSERT INTO ${ohdsiSchema}.sec_permission
+(value, description)
+values
+('cohortdefinition:global:share:put', 'special permission (intended for admins) that allows the user to share any cohort with a "global reader role"')
+;


### PR DESCRIPTION
Link to JIRA ticket if there is one: https://ctds-planx.atlassian.net/browse/VADC-1063
https://github.com/vinci-ohdsi/WebAPI-2-15-dev/pull/5/files

### New Features
- ensures new `sec_permission` is added to DB through flyway for new permission string that is used in https://github.com/uc-cdis/Atlas/pull/47

