### PR TITLE
Fix: add extra global share permission check

### DIFF
--- a/src/main/java/org/ohdsi/webapi/shiro/Entities/RoleEntity.java
+++ b/src/main/java/org/ohdsi/webapi/shiro/Entities/RoleEntity.java
@@ -23,6 +23,7 @@ import org.hibernate.annotations.Parameter;
 public class RoleEntity implements Serializable{
 
   private static final long serialVersionUID = 6257846375334314942L;
+  public static final int PUBLIC_ROLE_ID = 1;
 
   @Id
   @Column(name = "ID")

--- a/src/main/java/org/ohdsi/webapi/shiro/Entities/RoleEntity.java
+++ b/src/main/java/org/ohdsi/webapi/shiro/Entities/RoleEntity.java
@@ -11,6 +11,8 @@ import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
 import javax.persistence.OneToMany;
 import javax.persistence.Table;
+import org.apache.shiro.authz.permission.WildcardPermission;
+import org.apache.shiro.authz.Permission;
 import org.hibernate.annotations.GenericGenerator;
 import org.hibernate.annotations.Parameter;
 
@@ -89,5 +91,16 @@ public class RoleEntity implements Serializable{
 
   public void setSystemRole(Boolean system) {
     systemRole = system;
+  }
+
+  public boolean isPermitted(Permission p) {
+    for (RolePermissionEntity rolePermissionEntity : this.getRolePermissions()) {
+        PermissionEntity permissionEntity = rolePermissionEntity.getPermission();
+        WildcardPermission rolePermission = new WildcardPermission(permissionEntity.getValue());
+        if (rolePermission.implies(p)) {
+            return true;
+        }
+    }
+    return false;
   }
 }


### PR DESCRIPTION
Link to JIRA ticket if there is one: https://ctds-planx.atlassian.net/browse/VADC-1191


### Improvements
- fix: add extra check to ensure user has global sharing permission
### Dependency updates
- with this change, sharing with public role (roleId == 1) can now _only_ be done if the user has a specific "global sharing" permission AND the teamProject the user is currently logged in to has WRITE access to the item being shared