### PR TITLE
Fix: session vs token issue

### DIFF
--- a/src/main/java/org/ohdsi/webapi/shiro/PermissionManager.java
+++ b/src/main/java/org/ohdsi/webapi/shiro/PermissionManager.java
@@ -83,7 +83,7 @@ public class PermissionManager {
   
   private ThreadLocal<ConcurrentHashMap<String, UserSimpleAuthorizationInfo>> authorizationInfoCache = ThreadLocal.withInitial(ConcurrentHashMap::new);
 
-  private Map<AbstractMap.SimpleEntry<String,String>, String> teamProjectRoles = new HashMap<>();
+  private Map<String, String> teamProjectRoles = new HashMap<>();
 
   public static class PermissionsDTO {
 
@@ -658,25 +658,14 @@ public class PermissionManager {
     return this.roleRepository.existsByName(roleName);
   }
 
-  private String getCurrentUserSessionId() {
-    Subject subject = SecurityUtils.getSubject();
-    return subject.getSession(false).getId().toString();
-  }
-
-  private AbstractMap.SimpleEntry<String,String> getCurrentUserAndSessionTuple() {
-    AbstractMap.SimpleEntry<String, String> userAndSessionTuple = new AbstractMap.SimpleEntry<>
-      (getCurrentUser().getLogin(), getCurrentUserSessionId());
-    return userAndSessionTuple;
-  }
-
   public void setCurrentTeamProjectRoleForCurrentUser(String teamProjectRole, String login) {
     logger.debug("Current user in setCurrentTeamProjectRoleForCurrentUser() {}", login);
-    this.teamProjectRoles.put(getCurrentUserAndSessionTuple(), teamProjectRole);
+    this.teamProjectRoles.put(getCurrentUser().getLogin(), teamProjectRole);
   }
 
   public RoleEntity getCurrentTeamProjectRoleForCurrentUser() {
     logger.debug("Current user in getCurrentTeamProjectRoleForCurrentUser(): {}", getCurrentUser().getLogin());
-    String teamProjectRole = this.teamProjectRoles.get(getCurrentUserAndSessionTuple());
+    String teamProjectRole = this.teamProjectRoles.get(getCurrentUser().getLogin());
     if (teamProjectRole == null) {
       return null;
     } else {

--- a/src/main/java/org/ohdsi/webapi/shiro/filters/UpdateAccessTokenFilter.java
+++ b/src/main/java/org/ohdsi/webapi/shiro/filters/UpdateAccessTokenFilter.java
@@ -115,6 +115,11 @@ public class UpdateAccessTokenFilter extends AdviceFilter {
 
     login = UserUtils.toLowerCase(login);
 
+    // stop session to make logout of OAuth users possible
+    Session session = SecurityUtils.getSubject().getSession(false);
+    if (session != null) {
+      session.stop();
+    }
 
     if (jwt == null) {
       if (name == null) {


### PR DESCRIPTION
Link to JIRA ticket if there is one:  https://ctds-planx.atlassian.net/browse/VADC-1241

### Bug Fixes
- fix: restore back original `session.stop()` code from upstream. In practice this results in a behavior where the token expiry can be used to expire both the token and (indirectly - through a side-effect in upstream code) the session, and so `security.token.expiration` could be used to control session length (https://github.com/uc-cdis/cloud-automation/pull/2589)  
