### PR TITLE
moved from dockerhub to try and fix Snyk scan issues.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ RUN mvn package ${MAVEN_PARAMS} \
     && rm WebAPI.war
 
 # OHDSI WebAPI and ATLAS web application running as a Spring Boot application with Java 8
-FROM amazoncorretto:8u432-al2023-jre
+FROM public.ecr.aws/docker/library/amazoncorretto:8u432-al2023-jre
 
 # Any Java options to pass along, e.g. memory, garbage collection, etc.
 ENV JAVA_OPTS=""


### PR DESCRIPTION


### Dependency updates
Moved to ecr.public instead of dockerhub to try and fix a Snyk scan issue with sha' hashes on this image.