### PR TITLE
Feat: migration script to have cohort generation permission limited to team role

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,3 +80,8 @@ It was chosen to use embedded PG instead of H2 for unit tests since H2 doesn't s
 
 ## License
 OHDSI WebAPI is licensed under Apache License 2.0
+
+
+# Local dev
+
+Run with Broadsea (https://github.com/ohdsi/broadsea).

--- a/src/main/java/org/ohdsi/webapi/security/PermissionService.java
+++ b/src/main/java/org/ohdsi/webapi/security/PermissionService.java
@@ -66,6 +66,9 @@ public class PermissionService {
     @Value("${security.ohdsi.custom.authorization.mode}")
     private String authorizationMode;
 
+    // TODO - add something like @Value("${security.ohdsi.custom.authorization.teamProjectsPrefix}") to make this configurable
+    private String teamProjectsPrefix = "/gwas_projects/";
+
 	@Value("${security.defaultGlobalReadPermissions}")
 	private boolean defaultGlobalReadPermissions;
 
@@ -98,21 +101,24 @@ public class PermissionService {
     private void postConstruct() {
 
         this.repositories = new Repositories(appContext);
+        logger.info("PermissionService - AUTHORIZATION_MODE === '{}'", this.authorizationMode);
 
         // Migrated from Atlas security. Is it still required?
         for (Source source : sourceRepository.findAll()) {
-            RoleEntity sourceUserRole = sourcePermissionSchema.addSourceUserRole(source);
+            sourcePermissionSchema.addSourceUserRole(source);
             // validate that only teamproject roles have the "cohortdefinition:*:generate:%s:get"
             // permission if authorizationMode is "teamproject":
             if (this.authorizationMode.equals("teamproject")) {
                 String permissionToCheck = String.format("cohortdefinition:*:generate:%s:get", source.getSourceKey());
-                boolean permissionIsTiedToRole = finaAllRolesHavingPermissions(Collections.singletonList(permissionToCheck)).stream()
-                                    .anyMatch(r -> r.getId().equals(sourceUserRole.getId()));
+                logger.info("PermissionService - checking permission === '{}'", permissionToCheck);
+                List<String> notTeamProjectRoleNames  = finaAllRolesHavingPermissions(Collections.singletonList(permissionToCheck)).stream()
+                                    .filter(r -> !r.getName().startsWith(this.teamProjectsPrefix))
+                                    .map(RoleEntity::getName).collect(Collectors.toList());
 
-                if (permissionIsTiedToRole) {
-                    String errorText = String.format("Invalid permission found: %s. When 'teamproject' authorization mode is selected, "+
-                        "the cohortdefinition:*:generate permission needs to be assigned to teamproject roles and NOT to 'sourceuser' roles",
-                        permissionToCheck);
+                if (notTeamProjectRoleNames.size() > 0) {
+                    String errorText = String.format("Invalid permission configuration found for permission [%s]. When 'teamproject' authorization mode is selected, "+
+                        "the [%s] permission needs to be assigned to teamproject roles ONLY and NOT to other roles. Other roles found attached to this permission: %s",
+                        permissionToCheck, permissionToCheck, notTeamProjectRoleNames);
                     logger.error(errorText);
                     throw new RuntimeException(errorText);
                 }

--- a/src/main/java/org/ohdsi/webapi/security/PermissionService.java
+++ b/src/main/java/org/ohdsi/webapi/security/PermissionService.java
@@ -100,8 +100,22 @@ public class PermissionService {
 
         // Migrated from Atlas security. Is it still required?
         for (Source source : sourceRepository.findAll()) {
-            sourcePermissionSchema.addSourceUserRole(source);
-        }
+            RoleEntity sourceUserRole = sourcePermissionSchema.addSourceUserRole(source);
+            // validate that only teamproject roles have the "cohortdefinition:*:generate:%s:get"
+            // permission if authorizationMode is "teamproject":
+            if (this.authorizationMode.equals("teamproject")) {
+                for (RolePermissionEntity permission : sourceUserRole.getRolePermissions()) {
+                    String valueToCheck = String.format("cohortdefinition:*:generate:%s:get", source.getSourceKey());
+                    if (permission.getPermission().getValue().equals(valueToCheck)) {
+                        String errorText = String.format("Invalid permission found: %s. When 'teamproject' authorization mode is selected, "+
+                            "the cohortdefinition:*:generate permission needs to be assigned to teamproject roles and NOT to 'sourceuser' roles",
+                            permission);
+                        logger.error(errorText);
+                        throw new RuntimeException(errorText);
+                    }
+                }
+            }
+        }        
     }
 
     public List<RoleEntity> suggestRoles(String roleSearch) {

--- a/src/main/java/org/ohdsi/webapi/security/PermissionService.java
+++ b/src/main/java/org/ohdsi/webapi/security/PermissionService.java
@@ -33,6 +33,7 @@ import org.springframework.web.context.WebApplicationContext;
 import javax.annotation.PostConstruct;
 import java.io.Serializable;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -104,15 +105,16 @@ public class PermissionService {
             // validate that only teamproject roles have the "cohortdefinition:*:generate:%s:get"
             // permission if authorizationMode is "teamproject":
             if (this.authorizationMode.equals("teamproject")) {
-                for (RolePermissionEntity permission : sourceUserRole.getRolePermissions()) {
-                    String valueToCheck = String.format("cohortdefinition:*:generate:%s:get", source.getSourceKey());
-                    if (permission.getPermission().getValue().equals(valueToCheck)) {
-                        String errorText = String.format("Invalid permission found: %s. When 'teamproject' authorization mode is selected, "+
-                            "the cohortdefinition:*:generate permission needs to be assigned to teamproject roles and NOT to 'sourceuser' roles",
-                            permission);
-                        logger.error(errorText);
-                        throw new RuntimeException(errorText);
-                    }
+                String permissionToCheck = String.format("cohortdefinition:*:generate:%s:get", source.getSourceKey());
+                boolean permissionIsTiedToRole = finaAllRolesHavingPermissions(Collections.singletonList(permissionToCheck)).stream()
+                                    .anyMatch(r -> r.getId().equals(sourceUserRole.getId()));
+
+                if (permissionIsTiedToRole) {
+                    String errorText = String.format("Invalid permission found: %s. When 'teamproject' authorization mode is selected, "+
+                        "the cohortdefinition:*:generate permission needs to be assigned to teamproject roles and NOT to 'sourceuser' roles",
+                        permissionToCheck);
+                    logger.error(errorText);
+                    throw new RuntimeException(errorText);
                 }
             }
         }        

--- a/src/main/java/org/ohdsi/webapi/security/model/SourcePermissionSchema.java
+++ b/src/main/java/org/ohdsi/webapi/security/model/SourcePermissionSchema.java
@@ -4,14 +4,29 @@ import org.ohdsi.webapi.model.CommonEntity;
 import org.ohdsi.webapi.shiro.Entities.RoleEntity;
 import org.ohdsi.webapi.source.Source;
 import org.springframework.stereotype.Component;
+import org.springframework.beans.factory.annotation.Value;
 
 import java.util.HashMap;
 import java.util.Map;
+
+import javax.annotation.PostConstruct;
 
 import static org.ohdsi.webapi.shiro.management.Security.SOURCE_ACCESS_PERMISSION;
 
 @Component
 public class SourcePermissionSchema extends EntityPermissionSchema {
+
+    @Value("${security.ohdsi.custom.authorization.mode}")
+    private String authorizationMode;
+
+    @PostConstruct
+    public void init() {
+        // Only add this one to readPermissions map if NOT in "teamproject" mode. If in "teamproject" mode, we
+        // want this permission to (manually) be assigned (by an admin) to the teamproject roles instead:
+        if (!this.authorizationMode.equals("teamproject")) {
+            getReadPermissions().put("cohortdefinition:*:generate:%s:get", "Generate Cohort on Source with SourceKey = %s");
+        }
+    }
 
     private static Map<String, String> readPermissions = new HashMap<String, String>() {{
         put("cohortdefinition:*:report:%s:get", "Get Inclusion Rule Report for Source with SourceKey = %s");

--- a/src/main/java/org/ohdsi/webapi/security/model/SourcePermissionSchema.java
+++ b/src/main/java/org/ohdsi/webapi/security/model/SourcePermissionSchema.java
@@ -93,7 +93,7 @@ public class SourcePermissionSchema extends EntityPermissionSchema {
         dropSourceUserRole(commonEntity);
     }
 
-    public RoleEntity addSourceUserRole(CommonEntity commonEntity) {
+    public void addSourceUserRole(CommonEntity commonEntity) {
 
         Source source = (Source) commonEntity;
         final String roleName = getSourceRoleName(source.getSourceKey());
@@ -104,7 +104,6 @@ public class SourcePermissionSchema extends EntityPermissionSchema {
             role = permissionManager.addRole(roleName, true);
         }
         permissionManager.addPermissionsFromTemplate(role, getReadPermissions(), source.getSourceKey());
-        return role;
     }
 
     private void dropSourceUserRole(CommonEntity commonEntity) {

--- a/src/main/java/org/ohdsi/webapi/security/model/SourcePermissionSchema.java
+++ b/src/main/java/org/ohdsi/webapi/security/model/SourcePermissionSchema.java
@@ -30,7 +30,6 @@ public class SourcePermissionSchema extends EntityPermissionSchema {
 
     private static Map<String, String> readPermissions = new HashMap<String, String>() {{
         put("cohortdefinition:*:report:%s:get", "Get Inclusion Rule Report for Source with SourceKey = %s");
-        put("cohortdefinition:*:generate:%s:get", "Generate Cohort on Source with SourceKey = %s");
         put("cohortdefinition:*:cancel:%s:get", "Cancel Cohort Generation on Source with SourceKey = %s");
         put("vocabulary:%s:*:get", "Get vocabulary info on Source with SourceKey = %s");
         put("vocabulary:%s:included-concepts:count:post", "Get vocab concept counts on Source with SourceKey = %s");
@@ -94,7 +93,7 @@ public class SourcePermissionSchema extends EntityPermissionSchema {
         dropSourceUserRole(commonEntity);
     }
 
-    public void addSourceUserRole(CommonEntity commonEntity) {
+    public RoleEntity addSourceUserRole(CommonEntity commonEntity) {
 
         Source source = (Source) commonEntity;
         final String roleName = getSourceRoleName(source.getSourceKey());
@@ -105,6 +104,7 @@ public class SourcePermissionSchema extends EntityPermissionSchema {
             role = permissionManager.addRole(roleName, true);
         }
         permissionManager.addPermissionsFromTemplate(role, getReadPermissions(), source.getSourceKey());
+        return role;
     }
 
     private void dropSourceUserRole(CommonEntity commonEntity) {

--- a/src/main/resources/db/migration/postgresql/V2.15.0.20260605000000__custom_ctds_restricted_cohort_generation.sql
+++ b/src/main/resources/db/migration/postgresql/V2.15.0.20260605000000__custom_ctds_restricted_cohort_generation.sql
@@ -1,0 +1,10 @@
+-- Delete all sec_role_permission entries tied to permission 'cohortdefinition:%:generate:%:get'.
+-- This will give us a clean slate to start assigning this permission to only the "teamproject" roles:
+-- TODO - note that this assumes the whole system is running in "teamproject" mode... i.e. it is not configurable now.
+DELETE from ${ohdsiSchema}.sec_role_permission where sec_role_permission.permission_id in 
+(
+SELECT ${ohdsiSchema}.sec_permission.id
+FROM ${ohdsiSchema}.sec_permission
+where
+ sec_permission.value like 'cohortdefinition:%:generate:%:get'
+ );


### PR DESCRIPTION
Link to JIRA ticket if there is one: https://ctds-planx.atlassian.net/browse/VPODC-407

### New Features
- migration to ensure source generation permissions are removed, so that they can (as part of a separate process) be tied to team project roles
- updated logic to only assign `cohortdefinition:*:generate:%s:get` permission to sourceuser roles if NOT in "teamproject" authorization mode.
  - This means that, if WebAPI is configured to run in "teamproject" authorization mode (through `security.ohdsi.custom.authorization.mode` property), then the cohort generation permission should be assigned to "teamproject" roles instead of "sourceuser" roles.

### Breaking Changes

### Bug Fixes

### Improvements

### Dependency updates

### Deployment changes
<!-- This section should only contain important things devops should know when updating service versions. -->
